### PR TITLE
Fixed typo in function header

### DIFF
--- a/mdn.py
+++ b/mdn.py
@@ -71,12 +71,12 @@ def gaussian_probability(sigma, mu, target):
         probabilities (BxG): The probability of each point in the probability
             of the distribution in the corresponding sigma/mu index.
     """
-    data = data.unsqueeze(1).expand_as(sigma)
+    target = target.unsqueeze(1).expand_as(sigma)
     ret = ONEOVERSQRT2PI * torch.exp(-0.5 * ((data - mu) / sigma)**2) / sigma
     return torch.prod(ret, 2)
 
 
-def mdn_loss(pi, sigma, mu, data):
+def mdn_loss(pi, sigma, mu, target):
     """Calculates the error, given the MoG parameters and the target
 
     The loss is the negative log likelihood of the data given the MoG


### PR DESCRIPTION
Just fixed a quick typo to resolve #1 in the function headers of gaussian_probability and mdn_loss. 

Edit: Instead of target -> data in the function header, I changed data -> target in the function body. This stems from #2 not refactoring the whole function, and just changing the function header.